### PR TITLE
Update Dockerfiles for supported suites and minor race condition

### DIFF
--- a/dockerfiles/artful/Dockerfile
+++ b/dockerfiles/artful/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:precise
+FROM ubuntu:artful
 
 # https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
 RUN set -x \
@@ -23,10 +23,11 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys DD95CC430502E37EF840ACEEA5D32F012649A5A9 \
 	&& gpg --export DD95CC430502E37EF840ACEEA5D32F012649A5A9 > /etc/apt/trusted.gpg.d/neurodebian.gpg \
-	&& rm -r "$GNUPGHOME"
+	&& rm -rf "$GNUPGHOME" \
+	&& apt-key list | grep neurodebian
 
 RUN { \
-	echo 'deb http://neuro.debian.net/debian precise main'; \
+	echo 'deb http://neuro.debian.net/debian artful main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
-	echo '#deb-src http://neuro.debian.net/debian-devel precise main'; \
+	echo '#deb-src http://neuro.debian.net/debian-devel artful main'; \
 } > /etc/apt/sources.list.d/neurodebian.sources.list

--- a/dockerfiles/sid/Dockerfile
+++ b/dockerfiles/sid/Dockerfile
@@ -23,7 +23,8 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys DD95CC430502E37EF840ACEEA5D32F012649A5A9 \
 	&& gpg --export DD95CC430502E37EF840ACEEA5D32F012649A5A9 > /etc/apt/trusted.gpg.d/neurodebian.gpg \
-	&& rm -r "$GNUPGHOME"
+	&& rm -rf "$GNUPGHOME" \
+	&& apt-key list | grep neurodebian
 
 RUN { \
 	echo 'deb http://neuro.debian.net/debian sid main'; \

--- a/dockerfiles/stretch/Dockerfile
+++ b/dockerfiles/stretch/Dockerfile
@@ -23,7 +23,8 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys DD95CC430502E37EF840ACEEA5D32F012649A5A9 \
 	&& gpg --export DD95CC430502E37EF840ACEEA5D32F012649A5A9 > /etc/apt/trusted.gpg.d/neurodebian.gpg \
-	&& rm -r "$GNUPGHOME"
+	&& rm -rf "$GNUPGHOME" \
+	&& apt-key list | grep neurodebian
 
 RUN { \
 	echo 'deb http://neuro.debian.net/debian stretch main'; \

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -23,7 +23,8 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys DD95CC430502E37EF840ACEEA5D32F012649A5A9 \
 	&& gpg --export DD95CC430502E37EF840ACEEA5D32F012649A5A9 > /etc/apt/trusted.gpg.d/neurodebian.gpg \
-	&& rm -r "$GNUPGHOME"
+	&& rm -rf "$GNUPGHOME" \
+	&& apt-key list | grep neurodebian
 
 RUN { \
 	echo 'deb http://neuro.debian.net/debian trusty main'; \

--- a/dockerfiles/wheezy/Dockerfile
+++ b/dockerfiles/wheezy/Dockerfile
@@ -23,7 +23,8 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys DD95CC430502E37EF840ACEEA5D32F012649A5A9 \
 	&& gpg --export DD95CC430502E37EF840ACEEA5D32F012649A5A9 > /etc/apt/trusted.gpg.d/neurodebian.gpg \
-	&& rm -r "$GNUPGHOME"
+	&& rm -rf "$GNUPGHOME" \
+	&& apt-key list | grep neurodebian
 
 RUN { \
 	echo 'deb http://neuro.debian.net/debian wheezy main'; \

--- a/dockerfiles/xenial/Dockerfile
+++ b/dockerfiles/xenial/Dockerfile
@@ -23,7 +23,8 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys DD95CC430502E37EF840ACEEA5D32F012649A5A9 \
 	&& gpg --export DD95CC430502E37EF840ACEEA5D32F012649A5A9 > /etc/apt/trusted.gpg.d/neurodebian.gpg \
-	&& rm -r "$GNUPGHOME"
+	&& rm -rf "$GNUPGHOME" \
+	&& apt-key list | grep neurodebian
 
 RUN { \
 	echo 'deb http://neuro.debian.net/debian xenial main'; \

--- a/dockerfiles/yakkety/Dockerfile
+++ b/dockerfiles/yakkety/Dockerfile
@@ -23,7 +23,8 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys DD95CC430502E37EF840ACEEA5D32F012649A5A9 \
 	&& gpg --export DD95CC430502E37EF840ACEEA5D32F012649A5A9 > /etc/apt/trusted.gpg.d/neurodebian.gpg \
-	&& rm -r "$GNUPGHOME"
+	&& rm -rf "$GNUPGHOME" \
+	&& apt-key list | grep neurodebian
 
 RUN { \
 	echo 'deb http://neuro.debian.net/debian yakkety main'; \

--- a/dockerfiles/zesty/Dockerfile
+++ b/dockerfiles/zesty/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM ubuntu:zesty
 
 # https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
 RUN set -x \
@@ -27,7 +27,7 @@ RUN set -x \
 	&& apt-key list | grep neurodebian
 
 RUN { \
-	echo 'deb http://neuro.debian.net/debian jessie main'; \
+	echo 'deb http://neuro.debian.net/debian zesty main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
-	echo '#deb-src http://neuro.debian.net/debian-devel jessie main'; \
+	echo '#deb-src http://neuro.debian.net/debian-devel zesty main'; \
 } > /etc/apt/sources.list.d/neurodebian.sources.list

--- a/gen_dockerfiles
+++ b/gen_dockerfiles
@@ -106,7 +106,8 @@ RUN set -x \\
 	&& export GNUPGHOME="\$(mktemp -d)" \\
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys DD95CC430502E37EF840ACEEA5D32F012649A5A9 \\
 	&& gpg --export DD95CC430502E37EF840ACEEA5D32F012649A5A9 > /etc/apt/trusted.gpg.d/neurodebian.gpg \\
-	&& rm -r "\$GNUPGHOME"
+	&& rm -rf "\$GNUPGHOME" \\
+	&& apt-key list | grep neurodebian
 
 RUN { \\
 	echo 'deb http://neuro.debian.net/debian $release main'; \\


### PR DESCRIPTION
This updates all the supported versions for newer Ubuntu suites (and the now-EOL 12.04). :tada:

This also fixes some intermittent failures to build on newer GPG versions where socket files get created in `GNUPGHOME`, but while we `rm -r "$GNUPGHOME"`, the relevant daemons notice and shut down cleanly (including removing their socket), thus causing `rm` (and our build) to fail. Using `rm -rf` instead is a very simple fix. :+1: