### PR TITLE
Swap from "gnupg2" to "gnupg"

### DIFF
--- a/dockerfiles/artful-non-free/Dockerfile
+++ b/dockerfiles/artful-non-free/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/artful/Dockerfile
+++ b/dockerfiles/artful/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/buster-non-free/Dockerfile
+++ b/dockerfiles/buster-non-free/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/buster/Dockerfile
+++ b/dockerfiles/buster/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/jessie-non-free/Dockerfile
+++ b/dockerfiles/jessie-non-free/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/jessie/Dockerfile
+++ b/dockerfiles/jessie/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/sid-non-free/Dockerfile
+++ b/dockerfiles/sid-non-free/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/sid/Dockerfile
+++ b/dockerfiles/sid/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/stretch-non-free/Dockerfile
+++ b/dockerfiles/stretch-non-free/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/stretch/Dockerfile
+++ b/dockerfiles/stretch/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/trusty-non-free/Dockerfile
+++ b/dockerfiles/trusty-non-free/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/wheezy-non-free/Dockerfile
+++ b/dockerfiles/wheezy-non-free/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/wheezy/Dockerfile
+++ b/dockerfiles/wheezy/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/xenial-non-free/Dockerfile
+++ b/dockerfiles/xenial-non-free/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/xenial/Dockerfile
+++ b/dockerfiles/xenial/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/zesty-non-free/Dockerfile
+++ b/dockerfiles/zesty-non-free/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/dockerfiles/zesty/Dockerfile
+++ b/dockerfiles/zesty/Dockerfile
@@ -5,8 +5,6 @@ RUN set -x \
 	&& apt-get update \
 	&& { \
 		which gpg \
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \
 		|| apt-get install -y --no-install-recommends gnupg \
 	; } \
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr

--- a/gen_dockerfiles
+++ b/gen_dockerfiles
@@ -109,8 +109,6 @@ RUN set -x \\
 	&& apt-get update \\
 	&& { \\
 		which gpg \\
-# prefer gnupg2, to match APT's Recommends
-		|| apt-get install -y --no-install-recommends gnupg2 \\
 		|| apt-get install -y --no-install-recommends gnupg \\
 	; } \\
 # Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr


### PR DESCRIPTION
See https://github.com/docker-library/python/issues/236 for details.

~~I've successfully built all these `Dockerfile`s (and this includes the removal of the now-EOL `yakkety`).~~