### PR TITLE
Update gen_dockerfiles "library/neurodebian" output to use the new RFC 2822-based format

### DIFF
--- a/gen_dockerfiles
+++ b/gen_dockerfiles
@@ -147,26 +147,33 @@ else
 	git commit -m "Re-generated dockerfiles" dockerfiles
 fi
 
-current_treeish=$(git show | head -1 | awk '/^commit /{print $2;}')
-url_treeish=https://github.com/neurodebian/dockerfiles@$current_treeish
-debian_latest=$(awk '/^latest:/{print $3;}' stackbrew/library/debian)
+current_treeish=$(git rev-parse HEAD^{commit})
+debian_latest=$(awk -F '[ ,]+' '/latest/ { print $2; }' stackbrew/library/debian)
 
 print_verbose 1 "Populating ${ND_STACKBREW} for $release_tags"
-echo "# maintainer: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)" >| ${ND_STACKBREW}
+echo "Maintainers: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)" >| ${ND_STACKBREW}
+echo "GitRepo: https://github.com/neurodebian/dockerfiles.git" >> ${ND_STACKBREW}
+echo "GitCommit: $current_treeish" >> ${ND_STACKBREW}
 for release_rec in $release_tags; do
 	# NOTE: there might be a better way
 	release=${release_rec%_*}
 	release_suf=${release_rec##*_}
 	release_tag=$release$release_suf
-	echo -e "\n$release_tag: $url_treeish dockerfiles/$release_tag" >> ${ND_STACKBREW}
+	release_tags_all=$release_tag
 	bp_release=$($ND_CFG_TOOL -f $ND_CFG -F" " "release backport ids" ${release} | sed -e 's,.*=,,g')
 	if [ "$bp_release" != "" ]; then
-		echo "$bp_release$release_suf: $url_treeish dockerfiles/$release_tag" >> ${ND_STACKBREW}
+		release_tags_all+=", $bp_release$release_suf"
 	fi
 	# Let's use Debian's stable as our stable!
 	if [ "$release" = "$debian_latest" ]; then
-		echo "latest$release_suf: $url_treeish dockerfiles/$release_tag" >> ${ND_STACKBREW}
+		if [ "$release_suf" != "" ]; then
+			# "non-free"
+			release_tags_all+=", ${release_suf#-}"
+		else
+			release_tags_all+=", latest"
+		fi
 	fi
+	echo -e "\nTags: $release_tags_all\nDirectory: dockerfiles/$release_tag" >> ${ND_STACKBREW}
 done
 
 GIT_DIR=stackbrew/.git git add library/neurodebian


### PR DESCRIPTION
See https://github.com/docker-library/official-images#instruction-format for details on the newer format.

This makes it easier to update in the future, less error prone, and I've also updated the "upstream latest" detection.

Here's a diff to help illustrate:
```diff
diff --git a/library/neurodebian b/library/neurodebian
index 643cdd4d..163d0af2 100644
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -1,55 +1,57 @@
-# maintainer: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
+Maintainers: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
+GitRepo: https://github.com/neurodebian/dockerfiles.git
+GitCommit: c821b4f9597e72015c34d4e9f81025815daebb71
 
-trusty: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/trusty
-nd14.04: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/trusty
+Tags: trusty, nd14.04
+Directory: dockerfiles/trusty
 
-trusty-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/trusty-non-free
-nd14.04-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/trusty-non-free
+Tags: trusty-non-free, nd14.04-non-free
+Directory: dockerfiles/trusty-non-free
 
-xenial: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/xenial
-nd16.04: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/xenial
+Tags: xenial, nd16.04
+Directory: dockerfiles/xenial
 
-xenial-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/xenial-non-free
-nd16.04-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/xenial-non-free
+Tags: xenial-non-free, nd16.04-non-free
+Directory: dockerfiles/xenial-non-free
 
-zesty: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/zesty
-nd17.04: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/zesty
+Tags: zesty, nd17.04
+Directory: dockerfiles/zesty
 
-zesty-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/zesty-non-free
-nd17.04-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/zesty-non-free
+Tags: zesty-non-free, nd17.04-non-free
+Directory: dockerfiles/zesty-non-free
 
-artful: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/artful
-nd17.10: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/artful
+Tags: artful, nd17.10
+Directory: dockerfiles/artful
 
-artful-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/artful-non-free
-nd17.10-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/artful-non-free
+Tags: artful-non-free, nd17.10-non-free
+Directory: dockerfiles/artful-non-free
 
-wheezy: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/wheezy
-nd70: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/wheezy
+Tags: wheezy, nd70
+Directory: dockerfiles/wheezy
 
-wheezy-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/wheezy-non-free
-nd70-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/wheezy-non-free
+Tags: wheezy-non-free, nd70-non-free
+Directory: dockerfiles/wheezy-non-free
 
-jessie: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/jessie
-nd80: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/jessie
+Tags: jessie, nd80
+Directory: dockerfiles/jessie
 
-jessie-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/jessie-non-free
-nd80-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/jessie-non-free
+Tags: jessie-non-free, nd80-non-free
+Directory: dockerfiles/jessie-non-free
 
-stretch: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/stretch
-nd90: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/stretch
+Tags: stretch, nd90, latest
+Directory: dockerfiles/stretch
 
-stretch-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/stretch-non-free
-nd90-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/stretch-non-free
+Tags: stretch-non-free, nd90-non-free, non-free
+Directory: dockerfiles/stretch-non-free
 
-buster: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/buster
-nd100: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/buster
+Tags: buster, nd100
+Directory: dockerfiles/buster
 
-buster-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/buster-non-free
-nd100-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/buster-non-free
+Tags: buster-non-free, nd100-non-free
+Directory: dockerfiles/buster-non-free
 
-sid: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/sid
-nd: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/sid
+Tags: sid, nd
+Directory: dockerfiles/sid
 
-sid-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/sid-non-free
-nd-non-free: git://github.com/neurodebian/dockerfiles@ff9c3b42146d774585d860000e580ba7367d8101 dockerfiles/sid-non-free
+Tags: sid-non-free, nd-non-free
+Directory: dockerfiles/sid-non-free
```

And here's a diff from the `bashbrew`-generated version of the current file to this updated file:
```diff
--- /dev/fd/63	2017-11-01 14:58:42.493101835 -0700
+++ /dev/fd/62	2017-11-01 14:58:42.494101806 -0700
@@ -1,92 +1,57 @@
 Maintainers: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
-GitFetch: refs/heads/*
+GitRepo: https://github.com/neurodebian/dockerfiles.git
+GitCommit: c821b4f9597e72015c34d4e9f81025815daebb71
 
 Tags: trusty, nd14.04
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/trusty
 
 Tags: trusty-non-free, nd14.04-non-free
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/trusty-non-free
 
 Tags: xenial, nd16.04
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/xenial
 
 Tags: xenial-non-free, nd16.04-non-free
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/xenial-non-free
 
 Tags: zesty, nd17.04
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/zesty
 
 Tags: zesty-non-free, nd17.04-non-free
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/zesty-non-free
 
 Tags: artful, nd17.10
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/artful
 
 Tags: artful-non-free, nd17.10-non-free
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/artful-non-free
 
 Tags: wheezy, nd70
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/wheezy
 
 Tags: wheezy-non-free, nd70-non-free
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/wheezy-non-free
 
 Tags: jessie, nd80
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/jessie
 
 Tags: jessie-non-free, nd80-non-free
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/jessie-non-free
 
-Tags: stretch, nd90
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
+Tags: stretch, nd90, latest
 Directory: dockerfiles/stretch
 
-Tags: stretch-non-free, nd90-non-free
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
+Tags: stretch-non-free, nd90-non-free, non-free
 Directory: dockerfiles/stretch-non-free
 
 Tags: buster, nd100
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/buster
 
 Tags: buster-non-free, nd100-non-free
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/buster-non-free
 
 Tags: sid, nd
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/sid
 
 Tags: sid-non-free, nd-non-free
-GitRepo: git://github.com/neurodebian/dockerfiles
-GitCommit: ff9c3b42146d774585d860000e580ba7367d8101
 Directory: dockerfiles/sid-non-free
```
```diff
--- /dev/fd/63	2017-11-01 14:58:59.286602376 -0700
+++ /dev/fd/62	2017-11-01 14:58:59.287602346 -0700
@@ -24,8 +24,10 @@
 neurodebian:nd80-non-free
 neurodebian:stretch
 neurodebian:nd90
+neurodebian:latest
 neurodebian:stretch-non-free
 neurodebian:nd90-non-free
+neurodebian:non-free
 neurodebian:buster
 neurodebian:nd100
 neurodebian:buster-non-free
```