### PR TITLE
ENH: preinstall nd_freeze+eatmydata, and use eatmydata for all apt-get calls

### DIFF
--- a/dockerfiles/artful-non-free/Dockerfile
+++ b/dockerfiles/artful-non-free/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian artful main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel artful main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list; grep -q 'deb .* multiverse$' /etc/apt/sources.list || sed -i -e 's,universe *$,universe multiverse,g' /etc/apt/sources.list

--- a/dockerfiles/artful-non-free/Dockerfile
+++ b/dockerfiles/artful-non-free/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian artful main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel artful main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list; grep -q 'deb .* multiverse$' /etc/apt/sources.list || sed -i -e 's,universe *$,universe multiverse,g' /etc/apt/sources.list

--- a/dockerfiles/artful/Dockerfile
+++ b/dockerfiles/artful/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian artful main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel artful main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/artful/Dockerfile
+++ b/dockerfiles/artful/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian artful main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel artful main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/bionic-non-free/Dockerfile
+++ b/dockerfiles/bionic-non-free/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian bionic main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel bionic main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list; grep -q 'deb .* multiverse$' /etc/apt/sources.list || sed -i -e 's,universe *$,universe multiverse,g' /etc/apt/sources.list

--- a/dockerfiles/bionic-non-free/Dockerfile
+++ b/dockerfiles/bionic-non-free/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian bionic main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel bionic main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list; grep -q 'deb .* multiverse$' /etc/apt/sources.list || sed -i -e 's,universe *$,universe multiverse,g' /etc/apt/sources.list

--- a/dockerfiles/bionic/Dockerfile
+++ b/dockerfiles/bionic/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian bionic main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel bionic main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/bionic/Dockerfile
+++ b/dockerfiles/bionic/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian bionic main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel bionic main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/buster-non-free/Dockerfile
+++ b/dockerfiles/buster-non-free/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian buster main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel buster main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list /etc/apt/sources.list

--- a/dockerfiles/buster-non-free/Dockerfile
+++ b/dockerfiles/buster-non-free/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian buster main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel buster main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list /etc/apt/sources.list

--- a/dockerfiles/buster/Dockerfile
+++ b/dockerfiles/buster/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian buster main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel buster main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/buster/Dockerfile
+++ b/dockerfiles/buster/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian buster main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel buster main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/jessie-non-free/Dockerfile
+++ b/dockerfiles/jessie-non-free/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian jessie main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel jessie main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list /etc/apt/sources.list

--- a/dockerfiles/jessie-non-free/Dockerfile
+++ b/dockerfiles/jessie-non-free/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian jessie main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel jessie main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list /etc/apt/sources.list

--- a/dockerfiles/jessie/Dockerfile
+++ b/dockerfiles/jessie/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian jessie main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel jessie main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/jessie/Dockerfile
+++ b/dockerfiles/jessie/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian jessie main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel jessie main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/sid-non-free/Dockerfile
+++ b/dockerfiles/sid-non-free/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian sid main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel sid main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list /etc/apt/sources.list

--- a/dockerfiles/sid-non-free/Dockerfile
+++ b/dockerfiles/sid-non-free/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian sid main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel sid main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list /etc/apt/sources.list

--- a/dockerfiles/sid/Dockerfile
+++ b/dockerfiles/sid/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian sid main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel sid main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/sid/Dockerfile
+++ b/dockerfiles/sid/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian sid main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel sid main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/stretch-non-free/Dockerfile
+++ b/dockerfiles/stretch-non-free/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian stretch main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel stretch main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list /etc/apt/sources.list

--- a/dockerfiles/stretch-non-free/Dockerfile
+++ b/dockerfiles/stretch-non-free/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian stretch main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel stretch main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list /etc/apt/sources.list

--- a/dockerfiles/stretch/Dockerfile
+++ b/dockerfiles/stretch/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian stretch main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel stretch main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/stretch/Dockerfile
+++ b/dockerfiles/stretch/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian stretch main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel stretch main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/trusty-non-free/Dockerfile
+++ b/dockerfiles/trusty-non-free/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian trusty main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel trusty main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list; grep -q 'deb .* multiverse$' /etc/apt/sources.list || sed -i -e 's,universe *$,universe multiverse,g' /etc/apt/sources.list

--- a/dockerfiles/trusty-non-free/Dockerfile
+++ b/dockerfiles/trusty-non-free/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian trusty main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel trusty main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list; grep -q 'deb .* multiverse$' /etc/apt/sources.list || sed -i -e 's,universe *$,universe multiverse,g' /etc/apt/sources.list

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian trusty main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel trusty main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian trusty main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel trusty main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/wheezy-non-free/Dockerfile
+++ b/dockerfiles/wheezy-non-free/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian wheezy main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel wheezy main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list /etc/apt/sources.list

--- a/dockerfiles/wheezy-non-free/Dockerfile
+++ b/dockerfiles/wheezy-non-free/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian wheezy main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel wheezy main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list /etc/apt/sources.list

--- a/dockerfiles/wheezy/Dockerfile
+++ b/dockerfiles/wheezy/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian wheezy main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel wheezy main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/wheezy/Dockerfile
+++ b/dockerfiles/wheezy/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian wheezy main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel wheezy main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/xenial-non-free/Dockerfile
+++ b/dockerfiles/xenial-non-free/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian xenial main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel xenial main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list; grep -q 'deb .* multiverse$' /etc/apt/sources.list || sed -i -e 's,universe *$,universe multiverse,g' /etc/apt/sources.list

--- a/dockerfiles/xenial-non-free/Dockerfile
+++ b/dockerfiles/xenial-non-free/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian xenial main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel xenial main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's,main *$,main contrib non-free,g' /etc/apt/sources.list.d/neurodebian.sources.list; grep -q 'deb .* multiverse$' /etc/apt/sources.list || sed -i -e 's,universe *$,universe multiverse,g' /etc/apt/sources.list

--- a/dockerfiles/xenial/Dockerfile
+++ b/dockerfiles/xenial/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; }
+	; } \
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -27,17 +28,16 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian xenial main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel xenial main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list \
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \
+	&& rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/xenial/Dockerfile
+++ b/dockerfiles/xenial/Dockerfile
@@ -12,8 +12,7 @@ RUN set -x \
 	&& { \
 		gpg --version | grep -q '^gpg (GnuPG) 1\.' \
 		|| apt-get install -y --no-install-recommends dirmngr \
-	; } \
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -28,6 +27,17 @@ RUN { \
 	echo 'deb http://neuro.debian.net/debian xenial main'; \
 	echo 'deb http://neuro.debian.net/debian data main'; \
 	echo '#deb-src http://neuro.debian.net/debian-devel xenial main'; \
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 

--- a/gen_dockerfiles
+++ b/gen_dockerfiles
@@ -116,7 +116,8 @@ RUN set -x \\
 	&& { \\
 		gpg --version | grep -q '^gpg (GnuPG) 1\\.' \\
 		|| apt-get install -y --no-install-recommends dirmngr \\
-	; }
+	; } \\
+    && rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -131,18 +132,17 @@ RUN { \\
 	echo 'deb http://neuro.debian.net/debian $release main'; \\
 	echo 'deb http://neuro.debian.net/debian data main'; \\
 	echo '#deb-src http://neuro.debian.net/debian-devel $release main'; \\
-} > /etc/apt/sources.list.d/neurodebian.sources.list \\
-    && apt-get update
+} > /etc/apt/sources.list.d/neurodebian.sources.list
 
 # Minimalistic package to assist with freezing the APT configuration
 # which would be coming from neurodebian repo.
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
-RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \\
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
+RUN set -x \\
+    && apt-get update \\
+    && apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \\
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \\
+    && rm -rf /var/lib/apt/lists/*
 
 $sed_cmd
 EOF

--- a/gen_dockerfiles
+++ b/gen_dockerfiles
@@ -32,20 +32,20 @@ ae_verbose=3
 
 print_verbose()
 {
-    level=$1; shift
+	level=$1; shift
 	if [ "$ae_verbose" -ge $level ]; then
-        # use stderr for printing within functions stdout of which might be used
-        echo -n "I: " >&2
-        i=1; while [ $i -lt $level ]; do echo -ne " ">&2; i=$(($i+1)); done
-        echo -e "$*" >&2
-    fi
+		# use stderr for printing within functions stdout of which might be used
+		echo -n "I: " >&2
+		i=1; while [ $i -lt $level ]; do echo -ne " ">&2; i=$(($i+1)); done
+		echo -e "$*" >&2
+	fi
 }
 
 error()
 {
-    code=$1; shift
+	code=$1; shift
 	echo -e "E: $*" >&2
-    exit $code
+	exit $code
 }
 
 
@@ -92,8 +92,8 @@ for release in $all_releases; do
 				# free and -non-free flavors which might differ only in having NeuroDebian repo
 				# enabled for contrib and non-free
 				sed_cmd+="; grep -q 'deb .* multiverse$' /etc/apt/sources.list || sed -i -e 's,universe *$,universe multiverse,g' /etc/apt/sources.list";;
-            *) echo "Unknown base $base" >&2; exit 1;;
-        esac
+			*) echo "Unknown base $base" >&2; exit 1;;
+		esac
 	else
 		sed_cmd=
 	fi
@@ -117,7 +117,7 @@ RUN set -x \\
 		gpg --version | grep -q '^gpg (GnuPG) 1\\.' \\
 		|| apt-get install -y --no-install-recommends dirmngr \\
 	; } \\
-    && rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/*
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -139,10 +139,10 @@ RUN { \\
 # Also install and enable eatmydata to be used for all apt-get calls
 # to speed up docker builds.
 RUN set -x \\
-    && apt-get update \\
-    && apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \\
-    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \\
-    && rm -rf /var/lib/apt/lists/*
+	&& apt-get update \\
+	&& apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \\
+	&& ln -s /usr/bin/eatmydata /usr/local/bin/apt-get \\
+	&& rm -rf /var/lib/apt/lists/*
 
 $sed_cmd
 EOF
@@ -151,9 +151,9 @@ done
 
 git add dockerfiles
 if git status dockerfiles | grep -q 'nothing to commit'; then
- 	print_verbose 1 "No changes to dockerfiles - not committing anything"
+	print_verbose 1 "No changes to dockerfiles - not committing anything"
 else
- 	print_verbose 1 "Committing to GIT dockerfiles"
+	print_verbose 1 "Committing to GIT dockerfiles"
 	git commit -m "Re-generated dockerfiles" dockerfiles
 fi
 
@@ -188,8 +188,8 @@ done
 
 GIT_DIR=stackbrew/.git git add library/neurodebian
 if GIT_DIR=stackbrew/.git git status 2>&1 | grep -q 'nothing to commit'; then
- 	print_verbose 1 "No changes to stackbrew configuration - not committing anything"
+	print_verbose 1 "No changes to stackbrew configuration - not committing anything"
 else
- 	print_verbose 1 "Committing to GIT stackbrew"
+	print_verbose 1 "Committing to GIT stackbrew"
 	( cd stackbrew; echo git commit -m "Update NeuroDebian" library/neurodebian; )
 fi

--- a/gen_dockerfiles
+++ b/gen_dockerfiles
@@ -116,8 +116,7 @@ RUN set -x \\
 	&& { \\
 		gpg --version | grep -q '^gpg (GnuPG) 1\\.' \\
 		|| apt-get install -y --no-install-recommends dirmngr \\
-	; } \\
-	&& rm -rf /var/lib/apt/lists/*
+	; }
 
 # apt-key is a bit finicky during "docker build" with gnupg 2.x, so install the repo key the same way debian-archive-keyring does (/etc/apt/trusted.gpg.d)
 # this makes "apt-key list" output prettier too!
@@ -132,7 +131,18 @@ RUN { \\
 	echo 'deb http://neuro.debian.net/debian $release main'; \\
 	echo 'deb http://neuro.debian.net/debian data main'; \\
 	echo '#deb-src http://neuro.debian.net/debian-devel $release main'; \\
-} > /etc/apt/sources.list.d/neurodebian.sources.list
+} > /etc/apt/sources.list.d/neurodebian.sources.list \\
+    && apt-get update
+
+# Minimalistic package to assist with freezing the APT configuration
+# which would be coming from neurodebian repo.
+# Also install and enable eatmydata to be used for all apt-get calls
+# to speed up docker builds.
+RUN apt-get install -y --no-install-recommends neurodebian-freeze eatmydata \\
+    && ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
+
+# Clean up
+RUN rm -rf /var/lib/apt/lists/*
 
 $sed_cmd
 EOF


### PR DESCRIPTION
a bit of background

- `nd_freeze` is a fresh, alpha-stage script to be called at the top of Dockerfile's to "freeze" APT sources to specific datestamp and use Debian/NeuroDebian APT snapshot repositories. For Ubuntu it would not change/disable APT lines.  It is to make docker images reproducible.  Further improvements are planned but it seems to be working already quite nicely on sample use cases. (attn @mjtravers nd_freeze's author)

- `eatmydata` greatly improves speed of installation, and since data loss due to unannounced interruption of apt-get in docker container is unlikely if not impossible, I decided to make it default.

@tianon - do you see any reservations/problems possibly with those two improvements?
 if not, then I would merge and submit a PR for stackbrew to get this new flashy state of things ;)